### PR TITLE
Use npm modules instead of git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "qmlweb"]
-	path = qmlweb
-	url = https://github.com/qmlweb/qmlweb

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,4 @@
+# Authors ordered by first contribution.
+
+Michael Martin Moro <michael@unetresgrossebite.com>
+Сковорода Никита Андреевич <chalkerx@gmail.com>

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 var es = require('event-stream');
 var gutil = require('gulp-util');
-require(__dirname + '/qmlweb/src/qtcore/qml/QMLBinding.js');
-require(__dirname + '/qmlweb/src/qtcore/qml/lib/parser.js');
-require(__dirname + '/qmlweb/src/qtcore/qml/lib/jsparser.js');
+require('qmlweb/src/qtcore/qml/QMLBinding.js');
+require('qmlweb/src/qtcore/qml/lib/parser.js');
+require('qmlweb/src/qtcore/qml/lib/jsparser.js');
 
 module.exports = function (opt) {
   function modifyFile(file) {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "qmlweb/src/qtcore/qml/lib/jsparser.js"
   ],
   "dependencies": {
-    "event-stream": "",
-    "gulp-util": "~2.2.14",
+    "event-stream": "^3.3.2",
+    "gulp-util": "^3.0.7",
     "uglify-js": "^2.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,14 +3,12 @@
   "version": "0.0.1",
   "description": "compiles QML source files for use with the qmlweb library",
   "files": [
-    "index.js",
-    "qmlweb/src/qtcore/qml/QMLBinding.js",
-    "qmlweb/src/qtcore/qml/lib/parser.js",
-    "qmlweb/src/qtcore/qml/lib/jsparser.js"
+    "index.js"
   ],
   "dependencies": {
     "event-stream": "^3.3.2",
     "gulp-util": "^3.0.7",
+    "qmlweb": "~0.0.4",
     "uglify-js": "^2.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "gulp-qmlweb",
   "version": "0.0.1",
   "description": "compiles QML source files for use with the qmlweb library",
+  "repository": "qmlweb/gulp-qmlweb",
   "files": [
     "index.js"
   ],


### PR DESCRIPTION
Some npm package-related fixes.

This removes the git submodule (which btw works only on npm >= 3.7.0 which was just recently released) and uses npm modules instead.

/cc @Plaristote 
